### PR TITLE
Initial RESP3 support

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,13 @@
 Revision history for {{$dist->name}}
 
 {{$NEXT}}
+    New features:
+
+    - RESP3 support, for Redis 6
+    - pubsub is now allowed on the same connection as
+    other traffic if the connection is in RESP3 mode
+    - protocol is autodetected via `HELLO` command,
+    pass `protocol => 'resp2'` to disable this
 
 2.007     2020-09-05 02:08:25+08:00 Asia/Kuala_Lumpur
     New features:

--- a/examples/hincr.pl
+++ b/examples/hincr.pl
@@ -1,0 +1,46 @@
+#!/usr/bin/env perl 
+use strict;
+use warnings;
+
+use Net::Async::Redis;
+use Future::AsyncAwait;
+use IO::Async::Loop;
+
+use List::Util qw(min max);
+
+my $loop = IO::Async::Loop->new;
+$loop->add(my $redis = Net::Async::Redis->new);
+
+my $shutdown = $loop->new_future;
+$loop->watch_signal(
+    TERM => sub { $shutdown->done unless $shutdown->is_ready },
+    QUIT => sub { $shutdown->done unless $shutdown->is_ready },
+);
+
+(async sub {
+    await $redis->connect;
+    my ($min, $max, $avg, $last);
+    my $f = (async sub {
+        while(1) {
+            await $loop->delay_future(after => 1);
+            printf "Ping time - latest %.3fms, min/avg/max %.3fms/%.3fms/%.3fms\n", $last, $min, $avg, $max;
+        }
+    })->();
+    my $count = 0;
+    my $sum = 0;
+    until($shutdown->is_ready) {
+        my $start = Time::HiRes::time();
+        await Future->wait_all(
+            map { $redis->hincrbyfloat("some_key::" . rand(), rand(), int(100 * rand())) } 1..2000
+        );
+        my $elapsed = 1000.0 * (Time::HiRes::time() - $start);
+        ++$count;
+        $sum += $elapsed;
+        $min = min($elapsed, $min // ());
+        $max = max($elapsed, $max // ());
+        $avg = $sum / $count;
+        $last = $elapsed;
+    }
+    $f->cancel;
+})->()->get;
+

--- a/lib/Net/Async/Redis.pm
+++ b/lib/Net/Async/Redis.pm
@@ -67,7 +67,7 @@ Current features include:
 
 =over 4
 
-=item * L<all commands|https://redis.io/commands> as of 6.0.7 (August 2020), see L<https://redis.io/commands> for the methods and parameters
+=item * L<all commands|https://redis.io/commands> as of 6.0.7 (September 2020), see L<https://redis.io/commands> for the methods and parameters
 
 =item * L<pub/sub support|https://redis.io/topics/pubsub>, see L</METHODS - Subscriptions>
 

--- a/lib/Net/Async/Redis.pm
+++ b/lib/Net/Async/Redis.pm
@@ -811,6 +811,7 @@ item, depending on whether we're dealing with subscriptions at the moment.
 sub on_message {
     my ($self, $data) = @_;
     local @{$log->{context}}{qw(redis_remote redis_local)} = ($self->endpoint, $self->local_endpoint);
+
     $log->tracef('Incoming message: %s', $data);
     if(ref $data eq 'ARRAY' and $data->[0] eq 'subscribe') {
         my (undef, $chan, $count) = @$data;
@@ -854,7 +855,7 @@ sub next_in_pipeline {
 
 =head2 on_error_message
 
-
+Called when there's an error response.
 
 =cut
 

--- a/lib/Net/Async/Redis.pm
+++ b/lib/Net/Async/Redis.pm
@@ -936,6 +936,7 @@ sub client_name { shift->{client_name} }
 
 sub _init {
     my ($self, @args) = @_;
+    $self->{protocol_level} //= 'resp2';
     $self->{pending_multi} //= [];
     $self->{pending} //= [];
     $self->{awaiting_pipeline} //= [];

--- a/lib/Net/Async/Redis/Protocol.pm
+++ b/lib/Net/Async/Redis/Protocol.pm
@@ -17,8 +17,13 @@ Used internally by L<Net::Async::Redis> and L<Net::Async::Redis::Server>.
 
 use Scalar::Util qw(blessed reftype looks_like_number);
 use Log::Any qw($log);
+use List::Util qw(min);
 
-my $CRLF = "\x0D\x0A";
+# Normal string interpolation
+use constant CRLF => "\x0D\x0A";
+
+# Regex usage
+my $CRLF = CRLF;
 
 sub new { bless { @_[1..$#_] }, $_[0] }
 
@@ -37,22 +42,22 @@ sub encode {
     die 'blessed data is not ok' if blessed $data;
     if(my $type = reftype $data) {
         if($type eq 'ARRAY') {
-            return '*' . (0 + @$data) . $CRLF . join '', map $self->encode($_), @$data
+            return '*' . (0 + @$data) . CRLF . join '', map $self->encode($_), @$data
         } elsif($type eq 'HASH') {
             die 'no hash support'
         }
         die 'no support for ' . $type
     }
     if(!defined($data)) {
-        return '$-1' . $CRLF;
+        return '$-1' . CRLF;
     } elsif(!length($data)) {
-        return '$0' . $CRLF . $CRLF;
+        return '$0' . CRLF . CRLF;
     } elsif(($data ^ $data) eq "0" and int(0+$data) eq $data) {
-        return ':' . (0 + $data) . $CRLF;
+        return ':' . (0 + $data) . CRLF;
     } elsif(length($data) < 100 and $data !~ /[$CRLF]/) {
-        return '+' . $data . $CRLF;
+        return '+' . $data . CRLF;
     }
-    return '$' . length($data) . $CRLF . $data . $CRLF;
+    return '$' . length($data) . CRLF . $data . CRLF;
 }
 
 =head2 encode_from_client
@@ -64,8 +69,8 @@ convert them into length-prefixed bulk strings as a single response item.
 
 sub encode_from_client {
     my ($self, @data) = @_;
-    return '*' . (0 + @data) . $CRLF . join '', map {
-        '$' . length($_) . $CRLF . $_ . $CRLF
+    return '*' . (0 + @data) . CRLF . join '', map {
+        '$' . length($_) . CRLF . $_ . CRLF
     } @data;
 }
 
@@ -86,9 +91,13 @@ sub decode {
     my $len = $self->{parsing_bulk};
     ITEM:
     for ($$bytes) {
+        if($log->is_trace) {
+            my $bytes = substr $_, 0, min(16, length($_));
+            $log->tracef('Next few bytes: %s (%v02x)', $bytes, $bytes);
+        }
         if(defined($len)) {
             last ITEM unless length($_) >= $len + 2;
-            die 'invalid bulk data, did not end in CRLF' unless substr($_, $len, 2, '') eq $CRLF;
+            die 'invalid bulk data, did not end in CRLF' unless substr($_, $len, 2, '') eq CRLF;
             $self->item(substr $_, 0, delete $self->{parsing_bulk}, '');
             undef $len;
             last ITEM unless length;
@@ -99,24 +108,67 @@ sub decode {
             my $int = $1;
             die 'invalid integer value ' . $int unless looks_like_number($int) && int($int) eq $int;
             $self->item(0 + $int);
-        } elsif(s{^\$-1$CRLF}{}) {
-            $self->item(undef);
+        } elsif(s{^,([^\x0D]*)$CRLF}{}) {
+            my $num = $1;
+            die 'invalid numeric value ' . $num unless looks_like_number($num) && 0 + $num eq $num;
+            $self->item(0 + $num);
+        } elsif(s{^#([tf])$CRLF}{}) {
+            $self->item($1 eq 't');
         } elsif(s{^\$([0-9]+)$CRLF}{}) {
             $len = $1;
             die 'invalid numeric value for length ' . $len unless 0+$len eq $len;
             $self->{parsing_bulk} = $len;
-        } elsif(s{^\*-1$CRLF}{}) {
+        } elsif(s{^=([0-9]+)$CRLF}{}) {
+            $len = $1;
+            die 'invalid numeric value for length ' . $len unless 0+$len eq $len;
+            $self->{parsing_bulk} = $len;
+        } elsif(s{^\$-1$CRLF}{} or s{^\*-1$CRLF}{} or s{^_$CRLF}{}) {
             $self->item(undef);
+        } elsif(s{^>([0-9]+)$CRLF}{}) {
+            my $pending = $1;
+            die 'invalid numeric value for push ' . $pending unless 0+$pending eq $pending;
+            push @{$self->{active}}, {
+                type => 'push',
+                pending => $pending
+            } if $pending;
         } elsif(s{^\*([0-9]+)$CRLF}{}) {
             my $pending = $1;
             die 'invalid numeric value for array ' . $pending unless 0+$pending eq $pending;
             if($pending) {
-                push @{$self->{active}}, { array => $pending };
+                push @{$self->{active}}, { type => 'array', pending => $pending };
             } else {
-                $self->item([]);
+                $self->item([ ]);
             }
+        } elsif(s{^~([0-9]+)$CRLF}{}) {
+            my $pending = $1;
+            die 'invalid numeric value for set ' . $pending unless 0+$pending eq $pending;
+            if($pending) {
+                push @{$self->{active}}, { type => 'set', pending => $pending };
+            } else {
+                $self->item([ ]);
+            }
+        } elsif(s{^%([0-9]+)$CRLF}{}) {
+            my $pending = $1;
+            die 'invalid numeric value for map ' . $pending unless 0+$pending eq $pending;
+            if($pending) {
+                # We provide 2x the count here, for key/value pairs, and expect
+                # the handler to convert to a hash once it's received sufficient
+                # items to emit the full element
+                push @{$self->{active}}, { type => 'map', pending => 2 * $pending };
+            } else {
+                $self->item({ });
+            }
+        } elsif(s{^\|([0-9]+)$CRLF}{}) {
+            my $pending = $1;
+            die 'invalid numeric value for attribute ' . $pending unless 0+$pending eq $pending;
+            push @{$self->{active}}, {
+                type => 'attribute',
+                pending => 2 * $pending
+            } if $pending;
         } elsif(s{^-([^\x0D]*)$CRLF}{}) {
             $self->item_error($1);
+        } elsif(s{^!([^\x0D]*)$CRLF}{}) {
+            die 'cannot handle blob error yet';
         } else {
             last ITEM;
         }
@@ -132,8 +184,12 @@ sub item {
         return $self->{handler}->($data) unless @{$self->{active} || []};
 
         push @{$self->{active}[-1]{items}}, $data;
-        return if --$self->{active}[-1]{array};
-        $data = (pop @{$self->{active}})->{items};
+        return if --$self->{active}[-1]{pending};
+        my $active = pop @{$self->{active}};
+        $data = $active->{type} eq 'map' ? { @{$active->{items}} } : $active->{items};
+
+        # Skip attributes entirely for now
+        return if $active->{type} eq 'attribute';
     }
 }
 

--- a/lib/Net/Async/Redis/Protocol.pm
+++ b/lib/Net/Async/Redis/Protocol.pm
@@ -201,6 +201,12 @@ sub item_error {
     $self
 }
 
+sub item_pubsub {
+    my ($self, $item) = @_;
+    $self->{pubsub}->($item) if $self->{pubsub};
+    $self
+}
+
 1;
 
 __END__

--- a/lib/Net/Async/Redis/Protocol.pm
+++ b/lib/Net/Async/Redis/Protocol.pm
@@ -44,7 +44,7 @@ sub encode {
         if($type eq 'ARRAY') {
             return '*' . (0 + @$data) . CRLF . join '', map $self->encode($_), @$data
         } elsif($type eq 'HASH') {
-            die 'no hash support'
+            return '%' . (0 + keys %$data) . CRLF . join '', map $self->encode($_), %$data
         }
         die 'no support for ' . $type
     }

--- a/lib/Net/Async/Redis/Protocol.pm
+++ b/lib/Net/Async/Redis/Protocol.pm
@@ -52,7 +52,7 @@ sub encode {
         return $self->{protocol} eq 'resp3' ? '_' . CRLF : '$-1' . CRLF;
     } elsif(!length($data)) {
         return '$0' . CRLF . CRLF;
-    } elsif(($data ^ $data) eq "0" and int(0+$data) eq $data and lc($data) ne 'inf') {
+    } elsif(($data ^ $data) eq "0" and int(0+$data) eq $data and $data !~ /inf/i) {
         return ':' . (0 + $data) . CRLF;
     } elsif(($data ^ $data) eq "0" and 0+$data eq $data) {
         return ',' . lc(0 + $data) . CRLF;

--- a/lib/Net/Async/Redis/Protocol.pm
+++ b/lib/Net/Async/Redis/Protocol.pm
@@ -44,7 +44,7 @@ sub encode {
         if($type eq 'ARRAY') {
             return '*' . (0 + @$data) . CRLF . join '', map $self->encode($_), @$data
         } elsif($type eq 'HASH') {
-            return '%' . (0 + keys %$data) . CRLF . join '', map $self->encode($_), %$data
+            return '%' . (0 + keys %$data) . CRLF . join '', map $self->encode($_), map { $_ => $data->{$_} } sort keys %$data
         }
         die 'no support for ' . $type
     }

--- a/lib/Net/Async/Redis/Protocol.pm
+++ b/lib/Net/Async/Redis/Protocol.pm
@@ -52,10 +52,10 @@ sub encode {
         return $self->{protocol} eq 'resp3' ? '_' . CRLF : '$-1' . CRLF;
     } elsif(!length($data)) {
         return '$0' . CRLF . CRLF;
-    } elsif(($data ^ $data) eq "0" and int(0+$data) eq $data) {
+    } elsif(($data ^ $data) eq "0" and int(0+$data) eq $data and lc($data) ne 'inf') {
         return ':' . (0 + $data) . CRLF;
     } elsif(($data ^ $data) eq "0" and 0+$data eq $data) {
-        return ',' . (0 + $data) . CRLF;
+        return ',' . lc(0 + $data) . CRLF;
     } elsif(length($data) < 100 and $data !~ /[$CRLF]/) {
         return '+' . $data . CRLF;
     }
@@ -112,7 +112,7 @@ sub decode {
             $self->item(0 + $int);
         } elsif(s{^,([^\x0D]*)$CRLF}{}) {
             my $num = $1;
-            die 'invalid numeric value ' . $num unless looks_like_number($num) && 0 + $num eq $num;
+            die 'invalid numeric value ' . $num unless looks_like_number($num) && lc(0 + $num) eq lc($num);
             $self->item(0 + $num);
         } elsif(s{^#([tf])$CRLF}{}) {
             $self->item($1 eq 't');

--- a/lib/Net/Async/Redis/Protocol.pm
+++ b/lib/Net/Async/Redis/Protocol.pm
@@ -25,7 +25,7 @@ use constant CRLF => "\x0D\x0A";
 # Regex usage
 my $CRLF = CRLF;
 
-sub new { bless { @_[1..$#_] }, $_[0] }
+sub new { bless { protocol => 'resp3', @_[1..$#_] }, $_[0] }
 
 =head2 encode
 
@@ -49,11 +49,13 @@ sub encode {
         die 'no support for ' . $type
     }
     if(!defined($data)) {
-        return '$-1' . CRLF;
+        return $self->{protocol} eq 'resp3' ? '_' . CRLF : '$-1' . CRLF;
     } elsif(!length($data)) {
         return '$0' . CRLF . CRLF;
     } elsif(($data ^ $data) eq "0" and int(0+$data) eq $data) {
         return ':' . (0 + $data) . CRLF;
+    } elsif(($data ^ $data) eq "0" and 0+$data eq $data) {
+        return ',' . (0 + $data) . CRLF;
     } elsif(length($data) < 100 and $data !~ /[$CRLF]/) {
         return '+' . $data . CRLF;
     }

--- a/t/protocol.t
+++ b/t/protocol.t
@@ -38,6 +38,7 @@ my @resp2 = (
 my @resp3 = (
     [ "_$Z" => undef, 'single-character null' ],
     [ ",1.23$Z" => 1.23, 'double' ],
+    [ ",inf$Z" => 0+"Inf", 'infinity' ],
 );
 
 subtest decoding => sub {

--- a/t/protocol.t
+++ b/t/protocol.t
@@ -39,6 +39,7 @@ my @resp3 = (
     [ "_$Z" => undef, 'single-character null' ],
     [ ",1.23$Z" => 1.23, 'double' ],
     [ ",inf$Z" => 0+"Inf", 'infinity' ],
+    [ ",-inf$Z" => 0+"-Inf", 'infinity' ],
 );
 
 subtest decoding => sub {

--- a/t/protocol.t
+++ b/t/protocol.t
@@ -40,6 +40,12 @@ my @resp3 = (
     [ ",1.23$Z" => 1.23, 'double' ],
     [ ",inf$Z" => 0+"Inf", 'infinity' ],
     [ ",-inf$Z" => 0+"-Inf", 'infinity' ],
+    # Requires some poking around in internals, since
+    # we would only need this for the server implementation
+    # have left it out for now.
+    # [ "#t$Z" => !!1, 'true' ],
+    # [ "#f$Z" => !!0, 'false' ],
+    [ "%2$Z+key$Z:1$Z+second$Z:2$Z", +{ key => 1, second => 2 }, 'map' ],
 );
 
 subtest decoding => sub {

--- a/t/protocol.t
+++ b/t/protocol.t
@@ -17,9 +17,10 @@ use Test::HexString;
 use Net::Async::Redis::Protocol;
 
 my $Z = "\x0D\x0A";
-my @testcases = (
+my @resp2 = (
     [ "+OK$Z" => 'OK', 'simple string' ],
     [ ":123$Z" => 123, 'a number' ],
+    [ ":0$Z" => 0, 'zero integer' ],
     [ "+123.45$Z" => "123.45", 'floating-point number' ],
     [ "+123.0$Z" => "123.0", 'floating-point number that would be an integer without the trailing zero' ],
     [ "+123.4500$Z" => "123.4500", 'floating-point number with trailing zeroes' ],
@@ -34,12 +35,17 @@ my @testcases = (
     [ "*3$Z\$-1$Z:404$Z\$0$Z$Z" => [undef, 404, ""], 'mixed array' ],
 );
 
+my @resp3 = (
+    [ "_$Z" => undef, 'single-character null' ],
+    [ ",1.23$Z" => 1.23, 'double' ],
+);
+
 subtest decoding => sub {
     my $proto = new_ok('Net::Async::Redis::Protocol', [
         handler => sub { fail 'bad handler' }
     ]);
 
-    for my $case (@testcases) {
+    for my $case (@resp2, @resp3) {
         my ($bytes, $data, $msg) = @$case;
         my $call_count = 0;
         local $proto->{handler} = sub {
@@ -53,12 +59,26 @@ subtest decoding => sub {
     }
 };
 
-subtest encoding => sub {
+subtest 'RESP2 encoding' => sub {
     my $proto = new_ok('Net::Async::Redis::Protocol', [
+        protocol => 'resp2',
         handler => sub { fail 'bad handler' }
     ]);
 
-    for my $case (@testcases) {
+    for my $case (@resp2) {
+        my ($bytes, $data, $msg) = @$case;
+        my $actual = $proto->encode($data);
+        cmp_deeply($actual, $bytes, $msg // 'data matches');
+    }
+};
+
+subtest 'RESP3 encoding' => sub {
+    my $proto = new_ok('Net::Async::Redis::Protocol', [
+        protocol => 'resp3',
+        handler => sub { fail 'bad handler' }
+    ]);
+
+    for my $case (@resp3) {
         my ($bytes, $data, $msg) = @$case;
         my $actual = $proto->encode($data);
         cmp_deeply($actual, $bytes, $msg // 'data matches');
@@ -67,10 +87,11 @@ subtest encoding => sub {
 
 subtest roundtrip => sub {
     my $proto = new_ok('Net::Async::Redis::Protocol', [
+        protocol => 'resp2',
         handler => sub { fail 'bad handler' }
     ]);
 
-    for my $case (@testcases) {
+    for my $case (@resp2) {
         my ($bytes, $data, $msg) = @$case;
         my $original_bytes = $bytes;
         my $call_count = 0;

--- a/t/pubsub.t
+++ b/t/pubsub.t
@@ -38,11 +38,18 @@ isa_ok(my $sub = $subscriber->subscribe('test::somewhere')->get, 'Net::Async::Re
 is(exception {
     $subscriber->ping->get
 }, undef, 'can still ping after subscribe');
-like(exception {
-        note 'start';
-    $subscriber->get('test::random_key')->get;
-        note 'end';
-}, qr/pubsub/, 'but cannot GET while subscribed');
+
+if($subscriber->{protocol_level} eq 'resp2') {
+    like(exception {
+            note 'start';
+        $subscriber->get('test::random_key')->get;
+            note 'end';
+    }, qr/pubsub/, 'but cannot GET while subscribed');
+} else {
+    is(exception {
+        $subscriber->get('test::random_key')->get;
+    }, undef, 'can call GET while subscribed');
+}
 
 $sub->events->each(sub {
     note "Event - " . $_->payload;

--- a/t/watch_keyspace.t
+++ b/t/watch_keyspace.t
@@ -8,6 +8,11 @@ use IO::Async::Loop;
 
 plan skip_all => 'set NET_ASYNC_REDIS_HOST env var to test' unless exists $ENV{NET_ASYNC_REDIS_HOST};
 
+# If we have ::TAP, use it - but no need to list it as a dependency
+eval {
+    require Log::Any::Adapter;
+    Log::Any::Adapter->import(qw(TAP));
+};
 my $loop = IO::Async::Loop->new;
 $loop->add(my $redis = Net::Async::Redis->new);
 $loop->add(my $sub = Net::Async::Redis->new);
@@ -37,7 +42,7 @@ note "Delete key";
 is($redis->del('xyz')->get, 1, 'deleted a single key');
 note "Get key";
 ok(!$redis->exists('xyz')->get, 'no longer exists');
-is(@notifications, 0);
+is(@notifications, 0, 'had no notifications');
 
 $redis->set('testprefix-xyz' => 'test')->get;
 is($redis->get('testprefix-xyz')->get, 'test');


### PR DESCRIPTION
Extends Net::Async::Redis::Protocol to provide support for RESP3 extensions.

Since this is the default for newer Redis implementations and is backwards compatible, there's no attempt to split the implementations here: we just accept the newer values and can use the initial `HELLO` command to tell the server which protocol to send.