### PR TITLE
Handle cluster related errors differently

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,11 @@
 Revision history for {{$dist->name}}
 
 {{$NEXT}}
+    New features:
+
+    - ->bootstrap will now fail if the cluster's nodes addresses are not initiated.
+    - cluster->execute_command will now redirect the command to the correct node 
+      if 'MOVED' error received.
 
 3.009     2021-01-27 06:33:18+08:00 Asia/Kuala_Lumpur
     No new features.

--- a/cpanfile
+++ b/cpanfile
@@ -24,8 +24,10 @@ requires 'List::BinarySearch::XS', '>= 0.09';
 
 on 'test' => sub {
     requires 'Test::More', '>= 0.98';
+    requires 'Test::Fatal', '>= 0.016';
     requires 'Test::HexString', 0;
     requires 'Test::Deep', 0;
+    requires 'Test::MockModule', 0;
     requires 'Variable::Disposition', '>= 0.004';
 };
 

--- a/lib/Net/Async/Redis/Cluster.pm
+++ b/lib/Net/Async/Redis/Cluster.pm
@@ -224,8 +224,17 @@ async sub register_moved_slot {
     my $node = $self->node_by_host_port($host, $port);
      if(!$node) {
         $log->tracef("Failed to find node %s:%s in the original node list", $host, $port);
-        # Has a replica become a primary?
-        await $self->bootstrap(host => $host, port => $port);
+        # Has a replica become a primary? let's look for a vaild node
+        my $valid_connection;
+        for my $node ($self->{nodes}->@*) {
+            try {
+                $valid_connection = await $node->primary_connection;
+            } catch {
+                $log->tracef("Node at %s was invalid", $node->primary);
+            }
+        }
+        die 'Cluster status changed and cannot find a valid information source' unless $valid_connection;
+        await $self->apply_slots_from_instance($valid_connection);
         # Try again else propgate failure
         $node = $self->node_by_host_port($host, $port) or die "Slot $slot has been moved to unknown node";
     }

--- a/lib/Net/Async/Redis/Cluster/Node.pm
+++ b/lib/Net/Async/Redis/Cluster/Node.pm
@@ -28,6 +28,7 @@ sub from_arrayref {
     die 'invalid start' if $start > $end or $start < 0 or $start >= 16384;
     die 'invalid end' if $end >= 16384;
     die 'no primary found' unless $primary;
+    die 'invalid primary' unless $primary->[0] ne "" && $primary->[1] > 0;
     return $class->new(
         start    => $start,
         end      => $end,
@@ -35,6 +36,7 @@ sub from_arrayref {
         replicas => \@replicas,
     )
 }
+
 sub start { shift->{start} }
 sub end { shift->{end} }
 sub primary { shift->{primary} }

--- a/lib/Net/Async/Redis/Cluster/Node.pm
+++ b/lib/Net/Async/Redis/Cluster/Node.pm
@@ -7,10 +7,12 @@ use warnings;
 
 use parent qw(IO::Async::Notifier);
 
+use Scalar::Util qw(refaddr);
 use Future::AsyncAwait;
 
 use overload
     '""' => sub { 'NaRedis::Cluster::Node[id=' . shift->id . ']' },
+    '0+' => sub { refaddr(shift) },
     bool => sub { 1 },
     fallback => 1;
 

--- a/t/cluster.t
+++ b/t/cluster.t
@@ -7,6 +7,8 @@ use Syntax::Keyword::Try;
 use Future::AsyncAwait;
 
 use Test::More;
+use Test::Fatal qw(dies_ok lives_ok);
+use Test::MockModule;
 use Net::Async::Redis::Cluster;
 use IO::Async::Loop;
 
@@ -21,46 +23,111 @@ eval {
 };
 
 my $loop = IO::Async::Loop->new;
-(async sub {
-    $loop->add(
-        my $cluster = Net::Async::Redis::Cluster->new
-    );
 
-    await $cluster->bootstrap(
-        host => $ENV{NET_ASYNC_REDIS_HOST} // '127.0.0.1',
-        port => 6379,
-    );
-    my @nodes = $cluster->node_list;
-    is($cluster->node_for_slot(1), $nodes[0]);
-    is($cluster->node_for_slot(5500), $nodes[1]);
-    is($cluster->node_for_slot(12020), $nodes[2]);
-    try {
-        my $redis = await $cluster->connection_for_slot(0);
-        for my $k (qw(
-            abc
-            def
-            ghi
-            {user:100}.test
-            {user:101}.test
-            test.{user:100}
-            tset.{user:101}
-        )) {
-            is((await $redis->cluster_keyslot($k)), $cluster->hash_slot_for_key($k), 'server and our code agree on hash slot for ' . $k);
+subtest 'General cluster behaviour' => sub {
+    (async sub {
+        $loop->add(
+            my $cluster = Net::Async::Redis::Cluster->new
+        );
+
+        await $cluster->bootstrap(
+            host => $ENV{NET_ASYNC_REDIS_HOST} // '127.0.0.1',
+            port => 6379,
+        );
+        my @nodes = $cluster->node_list;
+        is($cluster->node_for_slot(1), $nodes[0]);
+        is($cluster->node_for_slot(5500), $nodes[1]);
+        is($cluster->node_for_slot(12020), $nodes[2]);
+        try {
+            my $redis = await $cluster->connection_for_slot(0);
+            for my $k (qw(
+                abc
+                def
+                ghi
+                {user:100}.test
+                {user:101}.test
+                test.{user:100}
+                tset.{user:101}
+            )) {
+                is((await $redis->cluster_keyslot($k)), $cluster->hash_slot_for_key($k), 'server and our code agree on hash slot for ' . $k);
+            }
+            await $redis->set(abc => 1);
+            await $redis->set(def => 1);
+            await $redis->set(ghi => 1);
+        } catch {
+            $log->errorf('error %s', $@);
+            my ($err, $key, $host_port) = split ' ', $@;
+            $log->errorf('Failed - %s - where key was %s, new target is %s', $err, $key, $host_port);
+            my $node = $cluster->register_moved_slot($key => $host_port);
+            $log->infof('New node is %s', $node);
+            is($node, $cluster->node_for_slot($key));
         }
-        await $redis->set(abc => 1);
-        await $redis->set(def => 1);
-        await $redis->set(ghi => 1);
-    } catch {
-        $log->errorf('error %s', $@);
-        my ($err, $key, $host_port) = split ' ', $@;
-        $log->errorf('Failed - %s - where key was %s, new target is %s', $err, $key, $host_port);
-        my $node = $cluster->register_moved_slot($key => $host_port);
-        $log->infof('New node is %s', $node);
-        is($node, $cluster->node_for_slot($key));
+        await $cluster->set(abc => 1);
+        await $cluster->set(def => 2);
+        await $cluster->set(ghi => 3);
+    })->()->get;
+};
+
+subtest 'Should abort if the cluster has invalid node(s)' => sub {
+    $loop->add(my $cluster = Net::Async::Redis::Cluster->new);
+    my $mocked_redis = Test::MockModule->new('Net::Async::Redis');
+    $mocked_redis->mock('cluster_slots', sub {
+        return Future->done([
+            [0, 500, ["127.0.0.1", 6379], ["127.0.0.1", 6380]],
+            [501, 1000, ["", 0], []]
+        ]);
+    });
+
+    dies_ok {
+        $cluster->bootstrap(
+            host => $ENV{NET_ASYNC_REDIS_HOST} // '127.0.0.1',
+            port => 6379
+        )->get();
+    }, 'Cluster bootstrap should throw an exception';
+};
+
+# Migrate a slot to the server who owns the slot in the next param
+
+async sub migrate_slot {
+    my ($cluster, $slot, $to) = @_;
+    my $source = await $cluster->connection_for_slot($slot);
+    my $src_id = await $source->cluster_myid;
+
+    my $destination = await $cluster->connection_for_slot($to);
+    my $dst_id = await $destination->cluster_myid;
+
+    await $destination->cluster_setslot($slot, importing => $src_id);
+    await $source->cluster_setslot($slot, migrating => $dst_id);
+    # 1000 is an arbitrary value here
+    my $keys_to_migrate = await $source->cluster_getkeysinslot($slot, 1000);
+    if ($keys_to_migrate->@*) {
+        await $source->migrate($destination->host, 6379, "", 0, 10, 'replace', keys => $keys_to_migrate->@*);
     }
-    await $cluster->set(abc => 1);
-    await $cluster->set(def => 2);
-    await $cluster->set(ghi => 3);
-})->()->get;
+    await $destination->cluster_setslot($slot, node => $dst_id);
+    await $source->cluster_setslot($slot, node => $dst_id);
+};
+
+subtest 'Should redirect request to correct node if MOVED error occurred' => sub {
+    $loop->add(my $cluster = Net::Async::Redis::Cluster->new);
+    (async sub {
+        await $cluster->bootstrap(
+            host => $ENV{NET_ASYNC_REDIS_HOST} // '127.0.0.1',
+            port => 6379
+        ); 
+
+        try {
+            # Migrate slot 3544 to the second server
+            await migrate_slot($cluster, 3544, 5500);
+            lives_ok {
+                $cluster->set('foo01', 'value')->get();
+                my $val = $cluster->get('foo01')->get();
+                is($val, 'value', 'received correct key value');
+            }, 'it should redirect the call to the correct server';
+        } finally {
+            # Migrate slot 3544 back
+            migrate_slot($cluster, 3544, 1)->get();
+        }
+    })->()->get();    
+};
 
 done_testing;

--- a/t/cluster.t
+++ b/t/cluster.t
@@ -58,7 +58,7 @@ subtest 'General cluster behaviour' => sub {
             $log->errorf('error %s', $@);
             my ($err, $key, $host_port) = split ' ', $@;
             $log->errorf('Failed - %s - where key was %s, new target is %s', $err, $key, $host_port);
-            my $node = $cluster->register_moved_slot($key => $host_port);
+            my $node = await $cluster->register_moved_slot($key => $host_port);
             $log->infof('New node is %s', $node);
             is($node, $cluster->node_for_slot($key));
         }

--- a/t/cluster.t
+++ b/t/cluster.t
@@ -7,7 +7,7 @@ use Syntax::Keyword::Try;
 use Future::AsyncAwait;
 
 use Test::More;
-use Test::Fatal qw(dies_ok lives_ok);
+use Test::Fatal qw(lives_ok exception);
 use Test::MockModule;
 use Net::Async::Redis::Cluster;
 use IO::Async::Loop;
@@ -78,12 +78,13 @@ subtest 'Should abort if the cluster has invalid node(s)' => sub {
         ]);
     });
 
-    dies_ok {
-        $cluster->bootstrap(
-            host => $ENV{NET_ASYNC_REDIS_HOST} // '127.0.0.1',
-            port => 6379
-        )->get();
-    }, 'Cluster bootstrap should throw an exception';
+    like(
+        exception {
+            $cluster->bootstrap(
+                host => $ENV{NET_ASYNC_REDIS_HOST} // '127.0.0.1',
+                port => 6379
+            )->get();
+    }, qr/invalid primary/, 'Cluster bootstrap should throw an exception');
 };
 
 # Migrate a slot to the server who owns the slot in the next param


### PR DESCRIPTION
- abort if the cluster has invalid connections at bootstrap.
- re-execute the command if received MOVED error.