### PR TITLE
Fix xgroup for cluster

### DIFF
--- a/lib/Net/Async/Redis.pm
+++ b/lib/Net/Async/Redis.pm
@@ -527,15 +527,6 @@ A string describing the local endpoint, usually C<host:port>.
 
 sub local_endpoint { shift->{local_endpoint} }
 
-# Helper for XGROUP, recent versions of the API split that out into
-# separate two-word commands in the manual so this is here to support
-# any legacy code which calls `->xgroup`.
-sub xgroup {
-    my ($self, $cmd, @args) = @_;
-    my $method = "xgroup_" . lc($cmd);
-    return $self->$method(@args);
-}
-
 =head1 METHODS - Subscriptions
 
 See L<https://redis.io/topics/pubsub> for more details on this topic.

--- a/lib/Net/Async/Redis/Commands.pm
+++ b/lib/Net/Async/Redis/Commands.pm
@@ -6126,6 +6126,36 @@ sub xdel : method {
     $self->execute_command(qw(XDEL) => @args)
 }
 
+=head2 xgroup
+
+Helper for XGROUP, recent versions of the API split that out into
+separate two-word commands in the manual so this is here to support
+any legacy code which calls `->xgroup`.
+
+=over 4
+
+=item * operation
+
+=item * key
+
+=item * groupname
+
+=item * id|$
+
+=item * [MKSTREAM]
+
+=back
+
+L<https://redis.io/commands/xgroup>
+
+=cut
+
+sub xgroup {
+    my ($self, $cmd, @args) = @_;
+    my $method = "xgroup_" . lc($cmd);
+    return $self->$method(@args);
+}
+
 =head2 xgroup_create
 
 Create a consumer group.


### PR DESCRIPTION
```
use strict;
use warnings;

use IO::Async::Loop;
use Future::AsyncAwait;
use Net::Async::Redis::Cluster;

use Log::Any::Adapter qw(Stderr), log_level => 'trace';
use Log::Any qw($log);

my $loop = IO::Async::Loop->new;
$loop->add(
    my $cluster = Net::Async::Redis::Cluster->new()
);
$loop->add(
    my $redis = Net::Async::Redis->new(host => 'redis6')
);

(async sub {
    await $cluster->bootstrap(
        host => 'redis-node-0',
        port => 6379
    );

    await $redis->xgroup('CREATE', 'testing', 'processors', '$', 'MKSTREAM');
    # Working
    # Outgoing [XGROUP CREATE testing processors $ MKSTREAM]
    # ...
    # Incoming message: OK, pending = XGROUP CREATE testing processors $ MKSTREAM


    await $cluster->xgroup('CREATE', 'testing', 'processors', '$', 'MKSTREAM');
    # Not working
    # Can't locate object method "xgroup" via package "Net::Async::Redis::Cluster"

})->()->get;
```

It's true that `Net::Async::Redis::Cluster` eventually uses an instance ($node) from `Net::Async::Redis` where it should allow `xgroup` to work in it's current method location.
However `Net::Async::Redis::Cluster` is only a child of `Net::Async::Redis::Commands` this is where the initial method lookup will happen before it reaches `execute_command` method which it will ultimately use an instance of `Net::Async::Redis`.

Since `xgroup` is still/already defined in  `Net::Async::Redis::Commands` `%KEY_FINDER` hash, also `https://redis.io/commands/xgroup` page is available. So I think it still makes sense to have `xgroup` defined as helper method in Commands class.

After this change is applied the above script is working for both `$redis` & `$cluster`