### PR TITLE
fix problem: handle reconnect correctly

### DIFF
--- a/lib/Net/Async/Redis.pm
+++ b/lib/Net/Async/Redis.pm
@@ -1161,13 +1161,10 @@ sub execute_command {
         $self->{connection_in_progress}
         ? Future->done
         # Are we the owner of a current MULTI transaction?
-        : $self->connected->then(
-            sub{
-                return $self->{_is_multi}
-                ? Future->wait_all(@{$self->{pending_multi}})
-                : Future->done()
-            }
-        )
+        : $self->{_is_multi}
+        ? $self->connnected
+        : Future->needs_all($self->connected,
+            Future->wait_all(@{$self->{pending_multi}}))
     )->then($code)
      ->retain;
 }

--- a/lib/Net/Async/Redis.pm
+++ b/lib/Net/Async/Redis.pm
@@ -1162,7 +1162,7 @@ sub execute_command {
         ? Future->done
         # Are we the owner of a current MULTI transaction?
         : $self->{_is_multi}
-        ? $self->connnected
+        ? $self->connected
         : Future->needs_all($self->connected,
             Future->wait_all(@{$self->{pending_multi}}))
     )->then($code)


### PR DESCRIPTION
fix problem: when redis restarted, the module cannot reconnect correctly, will hang there forever.
reproduce:
execute the following script:
```
use strict;
use warnings;
use feature qw(say);
use Syntax::Keyword::Try;
use Future::AsyncAwait;
use IO::Async::Loop;
use Net::Async::Redis;

my $loop         = IO::Async::Loop->new;
my $redis        = Net::Async::Redis->new(
    uri => 'redis://default:redispw@localhost:55001'
);
$loop->add($redis);

while (1) {

    #await $redis->xinfo(GROUPS => 'GENERIC_EVENTS_STREAM');
    say "will get";
    try {
        await $redis->get("abc");
        say "get done";
    }
    catch ($e) {
        say $e;
    }
    await $loop->delay_future( after => 1 );
    say "ok";
}

```

and stop then restart redis server. The script will  hang there forever.