### PR TITLE
handle disconnects in subscriber

### DIFF
--- a/lib/Net/Async/Redis/Subscription.pm
+++ b/lib/Net/Async/Redis/Subscription.pm
@@ -53,8 +53,8 @@ Normally called by L<Net::Async::Redis> itself once the subscription is no longe
 
 sub cancel {
     my ($self) = @_;
-    my $f = $self->events->completed;
-    $f->fail('cancelled') unless $f->is_ready;
+    my $f = $self->events;
+    $f->fail('cancelled') unless $f->completed->is_ready;
     $self
 }
 

--- a/t/pubsub.t
+++ b/t/pubsub.t
@@ -58,6 +58,32 @@ is(exception {
     $publisher->publish('test::somewhere' => 'example data')->get;
 }, undef, 'can publish without problems');
 
+# test that we detect and handle cases when redis closes the connection
+my $redis1 = Net::Async::Redis->new();
+$loop->add($redis1);
+my $rfut = $redis1->connect(
+        host => $ENV{NET_ASYNC_REDIS_HOST} // '127.0.0.1',
+        port => $ENV{NET_ASYNC_REDIS_PORT} // '6379',
+    )->then(
+        sub { $redis1->subscribe('non-existent-topic') }
+    );
+$rfut->await;
+my $sub_future;
+my $f = Future->needs_any(
+    $loop->timeout_future(after => 5),
+    $rfut->then(
+        async sub {
+            my $s = shift->events->map('payload');
+            $s->each(sub {});
+            $sub_future = $s->completed;
+            return $sub_future;
+        }
+    ),
+);
+$redis1->{stream}->close;
+$f->await;
+ok $sub_future->is_ready, "redis disconnect has been handled";
+
 done_testing;
 
 


### PR DESCRIPTION
when redis server closes connection on which we have a subscriber, the subscriber's future should be marked as ready, so as we could proceed further with reconnecting or handling the error in some other way. Currently the call to`$f->fail('cancelled')` fails with `"Completed state does not match internal state - if you are calling ->completed->failed, this will not work: use ->finish or ->fail instead at .../Ryu/Node.pm line 63."` and doesn't result in the future being marked as ready.